### PR TITLE
Hotfix: Disable CodeQL workflow for push to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   schedule:


### PR DESCRIPTION
This pull request disables the CodeQL workflow for push events to the main branch. The CodeQL workflow will still be triggered for pull requests and on a schedule. This change helps to optimize the workflow and reduce unnecessary checks for push events.